### PR TITLE
"'Fix parentage - some poms were using the wrong parent versions'"

### DIFF
--- a/mesakit-plugins/josm/pom.xml
+++ b/mesakit-plugins/josm/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>com.telenav</groupId>
         <artifactId>telenav-superpom-project-family</artifactId>
-        <version>2.0.0</version>
+        <version>2.0.3</version>
         <relativePath/>
     </parent>
 

--- a/pom.xml
+++ b/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>com.telenav</groupId>
         <artifactId>telenav-superpom-project-family</artifactId>
-        <version>2.0.0</version>
+        <version>2.0.3</version>
         <relativePath/>
     </parent>
 


### PR DESCRIPTION
"'Fix parentage - some poms were using the wrong parent versions'



Related Pull Requests
---------------------

  * https://github.com/Telenav/kivakit/pull/137
  * https://github.com/Telenav/mesakit-examples/pull/3
  * https://github.com/Telenav/kivakit-extensions/pull/36
  * https://github.com/Telenav/kivakit-examples/pull/18
  * https://github.com/Telenav/kivakit-stuff/pull/12
  * https://github.com/Telenav/mesakit/pull/19


Creating Pull Requests In
-------------------------

  * kivakit fix-parentage -> develop
  * kivakit-examples fix-parentage -> develop
  * kivakit-extensions fix-parentage -> develop
  * kivakit-stuff fix-parentage -> develop
  * mesakit fix-parentage -> develop
  * mesakit-examples fix-parentage -> develop
  * mesakit-extensions fix-parentage -> develop
  * telenav-superpom fix-parentage -> develop
  * jonstuff fix-parentage -> develop


Metadata
--------

  * Invoked on com.telenav:telenav-build:2.0.2
  * SearchNonce: 2dURfVuCra-rgwpnk

##### Provenance

Generated by cactus: *cactus-maven-plugin* version _1.5.24_.

  * Mojo:		GitPullRequestMojo
  * Generation-Time:	2022-08-20T09:14:21Z
  * Plugin-Build:	tungsten bobblehead
  * Plugin-Date:	2022.08.20
  * Plugin-Commit:	ff344f3f6018695190d41b72b9c850b9fcb36eaa
  * Plugin-Repo-Clean:	false
"